### PR TITLE
Specify a restrict key

### DIFF
--- a/migrations/verify.go
+++ b/migrations/verify.go
@@ -33,6 +33,8 @@ func dump(c *PostgresConfig) ([]byte, error) {
 		"-h", c.Host,
 		"-p", c.Port,
 		"-U", c.User,
+		// if not specified, will be random, so not repeatable
+		"--restrict-key=key",
 		c.Database)
 	cmd.Dir = tempDir
 	cmd.Env = append(cmd.Env, "PGPASSFILE="+passFilePath)


### PR DESCRIPTION
Testing: downloaded a sufficiently recent version of pg_dump that it uses a restrict key. Observed that `go run ./cmd/schema-test` fails without this change. With this change, it succeeds.

## PR Checklist
* [ ] **New automated tests have been written to the extent possible.**
* [x] **The code has been checked for structural/syntactic validity.**
	- AMI/application: a build was performed
	- terraform changes: "terraform plan" checked on every affected environment
* [ ] **(If applicable) the code has been manually tested on our infrastructure.**
	- AMI/application: deployed an a test or dev environment
	- terraform changes: applied to test or dev environment
	- script: run against test or dev environment
* [x] **Likely failure points and new functionality have been identified and tested manually.**
	Examples:
	- Application manually run in a way that triggers any new branches
	- AMI logged into and changes verified from login shell
* [x] **Pull request description includes a description of all the manual steps performed to accomplish the above.**

To provide feedback on this template, visit https://docs.google.com/document/d/1YfTv7Amyop5G_8w1c2GJ_Mu-70L0KkZHhm9f9umDi3U/edit
