### PR TITLE
[CMCSMACD-4253] Run each migration in its own transaction

### DIFF
--- a/cmd/schema-test/migrations.go
+++ b/cmd/schema-test/migrations.go
@@ -68,4 +68,13 @@ var allMigrations = []migrations.NamedMigration{
 			`DROP TYPE type1_old`,
 		}),
 	},
+	{
+		Name: "Create a view referencing a new enum value",
+		Migration: migrations.StaticMigration([]string{
+			`CREATE VIEW v AS SELECT * FROM table3 WHERE v = 'type1val3'`,
+		}),
+		Reverse: migrations.StaticMigration([]string{
+			`DROP VIEW v`,
+		}),
+	},
 }


### PR DESCRIPTION
Some types of changes (like adding new enum values) cannot be used until after the transaction including them is committed.[0]

As part of this change, the verification program is updated to:
- include a migration that fails if it is included in the same transaction as the previous migration
- call Migrate() on all migrations once before calling it on each one individually which reproduces the error that this change fixes.

[0] https://www.postgresql.org/docs/16/sql-altertype.html

## PR Checklist
* [x] **New automated tests have been written to the extent possible.**
* [x] **The code has been checked for structural/syntactic validity.**
	- AMI/application: a build was performed
	- terraform changes: "terraform plan" checked on every affected environment
* [ ] **(If applicable) the code has been manually tested on our infrastructure.**
	- AMI/application: deployed an a test or dev environment
	- terraform changes: applied to test or dev environment
	- script: run against test or dev environment
* [ ] **Likely failure points and new functionality have been identified and tested manually.**
	Examples:
	- Application manually run in a way that triggers any new branches
	- AMI logged into and changes verified from login shell
* [ ] **Pull request description includes a description of all the manual steps performed to accomplish the above.**

To provide feedback on this template, visit https://docs.google.com/document/d/1YfTv7Amyop5G_8w1c2GJ_Mu-70L0KkZHhm9f9umDi3U/edit
