### PR TITLE
RDS IAM token signing callback

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,11 @@ module github.com/corbaltcode/go-libraries
 go 1.24
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.41.0
+	github.com/aws/aws-sdk-go-v2 v1.41.4
 	github.com/aws/aws-sdk-go-v2/config v1.31.0
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.5
 	github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.16
+	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.55.2
 	github.com/aws/aws-sdk-go-v2/service/rds v1.113.1
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.63.0
@@ -20,14 +21,14 @@ require (
 
 require (
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.16 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.16 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.16 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.20 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.20 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.16 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.12 // indirect
-	github.com/aws/smithy-go v1.24.0 // indirect
+	github.com/aws/smithy-go v1.24.2 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/aws/aws-sdk-go-v2 v1.41.0 h1:tNvqh1s+v0vFYdA1xq0aOJH+Y5cRyZ5upu6roPgPKd4=
-github.com/aws/aws-sdk-go-v2 v1.41.0/go.mod h1:MayyLB8y+buD9hZqkCW3kX1AKq07Y5pXxtgB+rRFhz0=
+github.com/aws/aws-sdk-go-v2 v1.41.4 h1:10f50G7WyU02T56ox1wWXq+zTX9I1zxG46HYuG1hH/k=
+github.com/aws/aws-sdk-go-v2 v1.41.4/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
 github.com/aws/aws-sdk-go-v2/config v1.31.0 h1:9yH0xiY5fUnVNLRWO0AtayqwU1ndriZdN78LlhruJR4=
 github.com/aws/aws-sdk-go-v2/config v1.31.0/go.mod h1:VeV3K72nXnhbe4EuxxhzsDc/ByrCSlZwUnWH52Nde/I=
 github.com/aws/aws-sdk-go-v2/credentials v1.19.5 h1:xMo63RlqP3ZZydpJDMBsH9uJ10hgHYfQFIk1cHDXrR4=
@@ -8,12 +8,14 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.16 h1:80+uETIWS1BqjnN9uJ0dBU
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.16/go.mod h1:wOOsYuxYuB/7FlnVtzeBYRcjSRtQpAW0hCP7tIULMwo=
 github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.16 h1:LFB4eCU2S9wpFAkEnSqtP8CgdOk0cjMIzuXas1+rbWM=
 github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.16/go.mod h1:Q7hjCcQzFZ9QgZ+xeJhO4X1rv7uKAl4aoBEjab6MS8k=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.16 h1:rgGwPzb82iBYSvHMHXc8h9mRoOUBZIGFgKb9qniaZZc=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.16/go.mod h1:L/UxsGeKpGoIj6DxfhOWHWQ/kGKcd4I1VncE4++IyKA=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.16 h1:1jtGzuV7c82xnqOVfx2F0xmJcOw5374L7N6juGW6x6U=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.16/go.mod h1:M2E5OQf+XLe+SZGmmpaI2yy+J326aFf6/+54PoxSANc=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.20 h1:CNXO7mvgThFGqOFgbNAP2nol2qAWBOGfqR/7tQlvLmc=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.20/go.mod h1:oydPDJKcfMhgfcgBUZaG+toBbwy8yPWubJXBVERtI4o=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.20 h1:tN6W/hg+pkM+tf9XDkWUbDEjGLb+raoBMFsTodcoYKw=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.20/go.mod h1:YJ898MhD067hSHA6xYCx5ts/jEd8BSOLtQDL3iZsvbc=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 h1:bIqFDwgGXXN1Kpp99pDOdKMTTb5d2KyU5X/BZxjOkRo=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3/go.mod h1:H5O/EsxDWyU+LP/V8i5sm8cxoZgc2fdNR9bxlOFrQTo=
+github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.55.2 h1:mleWBVIxwceEzyItUVoqMFiv6TmOP6ECPoN6WB/VWXc=
+github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.55.2/go.mod h1:cMApt548kNgu87UsBTNWVv+fpzjbUTFRSFjD1688SBs=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.4 h1:0ryTNEdJbzUCEWkVXEXoqlXV72J5keC1GvILMOuD00E=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.4/go.mod h1:HQ4qwNZh32C3CBeO6iJLQlgtMzqeG17ziAA/3KDJFow=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.16 h1:oHjJHeUy0ImIV0bsrX0X91GkV5nJAyv1l1CC9lnO0TI=
@@ -30,8 +32,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.12 h1:AHDr0DaHIAo8c9t1emrzAlV
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.12/go.mod h1:GQ73XawFFiWxyWXMHWfhiomvP3tXtdNar/fi8z18sx0=
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.5 h1:SciGFVNZ4mHdm7gpD1dgZYnCuVdX1s+lFTg4+4DOy70=
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.5/go.mod h1:iW40X4QBmUxdP+fZNOpfmkdMZqsovezbAeO+Ubiv2pk=
-github.com/aws/smithy-go v1.24.0 h1:LpilSUItNPFr1eY85RYgTIg5eIEPtvFbskaFcmmIUnk=
-github.com/aws/smithy-go v1.24.0/go.mod h1:LEj2LM3rBRQJxPZTB4KuzZkaZYnZPnvgIhb4pu07mx0=
+github.com/aws/smithy-go v1.24.2 h1:FzA3bu/nt/vDvmnkg+R8Xl46gmzEDam6mZ1hzmwXFng=
+github.com/aws/smithy-go v1.24.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/coreos/go-oidc/v3 v3.6.0 h1:AKVxfYw1Gmkn/w96z0DbT/B/xFnzTd3MkZvWLjF4n/o=
 github.com/coreos/go-oidc/v3 v3.6.0/go.mod h1:ZpHUsHBucTUj6WOkrP4E20UPynbLZzhTQ1XKCXkxyPc=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/pgutils/connector.go
+++ b/pgutils/connector.go
@@ -35,7 +35,7 @@ type TokenSignEvent struct {
 
 // OnTokenSign is called synchronously after an RDS IAM auth token is generated.
 // Because it runs on the ConnectionString path, implementations should keep
-// their work lightweight. Pass nil to disable notifications.
+// their work lightweight. Omit when constructing a provider and notifications are not needed.
 type OnTokenSign func(ctx context.Context, event TokenSignEvent)
 
 // ConnectionStringProvider returns a Postgres connection string for use by clients
@@ -64,10 +64,10 @@ func (f connectionStringProviderFunc) ConnectionString(ctx context.Context) (str
 //
 //	postgres+rds-iam://<user>@<rds-endpoint>:<port>/<db-name>?assume_role_arn=<...>&assume_role_session_name=<...>
 //
-// For postgres+rds-iam, the provider generates a fresh IAM auth token on each
-// ConnectionString(ctx) call and fires onTokenSign (if non-nil) synchronously
-// after each successful signing.
-func NewConnectionStringProviderFromURLString(ctx context.Context, rawURL string, onTokenSign OnTokenSign) (ConnectionStringProvider, error) {
+// For postgres+rds-iam, the provider generates a fresh IAM auth token on
+// each ConnectionString(ctx) call. Any onTokenSign callbacks are invoked
+// synchronously after each successful signing.
+func NewConnectionStringProviderFromURLString(ctx context.Context, rawURL string, onTokenSign ...OnTokenSign) (ConnectionStringProvider, error) {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return nil, fmt.Errorf("parsing URL: %w", err)
@@ -185,7 +185,7 @@ type rdsIAMConnectionStringProvider struct {
 	CredentialsProvider   aws.CredentialsProvider
 	AssumeRoleARN         string
 	AssumeRoleSessionName string
-	OnTokenSign           OnTokenSign
+	OnTokenSign           []OnTokenSign
 }
 
 func (p *rdsIAMConnectionStringProvider) ConnectionString(ctx context.Context) (string, error) {
@@ -194,14 +194,15 @@ func (p *rdsIAMConnectionStringProvider) ConnectionString(ctx context.Context) (
 		return "", fmt.Errorf("building auth token: %w", err)
 	}
 
-	if p.OnTokenSign != nil {
-		p.OnTokenSign(ctx, TokenSignEvent{
-			Endpoint:              p.RDSEndpoint,
-			User:                  p.User,
-			Database:              p.Database,
-			AssumeRoleARN:         p.AssumeRoleARN,
-			AssumeRoleSessionName: p.AssumeRoleSessionName,
-		})
+	event := TokenSignEvent{
+		Endpoint:              p.RDSEndpoint,
+		User:                  p.User,
+		Database:              p.Database,
+		AssumeRoleARN:         p.AssumeRoleARN,
+		AssumeRoleSessionName: p.AssumeRoleSessionName,
+	}
+	for _, callback := range p.OnTokenSign {
+		callback(ctx, event)
 	}
 
 	dsnURL := &url.URL{
@@ -214,7 +215,7 @@ func (p *rdsIAMConnectionStringProvider) ConnectionString(ctx context.Context) (
 	return dsnURL.String(), nil
 }
 
-func newIAMConnectionStringProviderFromURL(ctx context.Context, u *url.URL, onTokenSign OnTokenSign) (ConnectionStringProvider, error) {
+func newIAMConnectionStringProviderFromURL(ctx context.Context, u *url.URL, onTokenSign []OnTokenSign) (ConnectionStringProvider, error) {
 	user := ""
 	if u.User != nil {
 		user = u.User.Username()

--- a/pgutils/connector.go
+++ b/pgutils/connector.go
@@ -33,10 +33,10 @@ type TokenSignEvent struct {
 	AssumeRoleSessionName string // empty if no role assumption was configured
 }
 
-// OnTokenSign is called each time an RDS IAM auth token is generated.
-// Clients can use this for logging, metrics, or any other observability needs.
-// Pass nil to disable notifications.
-type OnTokenSign func(event TokenSignEvent)
+// OnTokenSign is called synchronously after an RDS IAM auth token is generated.
+// Because it runs on the ConnectionString path, implementations should keep
+// their work lightweight. Pass nil to disable notifications.
+type OnTokenSign func(ctx context.Context, event TokenSignEvent)
 
 // ConnectionStringProvider returns a Postgres connection string for use by clients
 // that need a DSN (e.g., pq.Listener) or to build a connector.
@@ -65,7 +65,8 @@ func (f connectionStringProviderFunc) ConnectionString(ctx context.Context) (str
 //	postgres+rds-iam://<user>@<rds-endpoint>:<port>/<db-name>?assume_role_arn=<...>&assume_role_session_name=<...>
 //
 // For postgres+rds-iam, the provider generates a fresh IAM auth token on each
-// ConnectionString(ctx) call and fires onTokenSign (if non-nil) after each signing.
+// ConnectionString(ctx) call and fires onTokenSign (if non-nil) synchronously
+// after each successful signing.
 func NewConnectionStringProviderFromURLString(ctx context.Context, rawURL string, onTokenSign OnTokenSign) (ConnectionStringProvider, error) {
 	u, err := url.Parse(rawURL)
 	if err != nil {
@@ -194,7 +195,7 @@ func (p *rdsIAMConnectionStringProvider) ConnectionString(ctx context.Context) (
 	}
 
 	if p.OnTokenSign != nil {
-		p.OnTokenSign(TokenSignEvent{
+		p.OnTokenSign(ctx, TokenSignEvent{
 			Endpoint:              p.RDSEndpoint,
 			User:                  p.User,
 			Database:              p.Database,
@@ -263,9 +264,10 @@ func newIAMConnectionStringProviderFromURL(ctx context.Context, u *url.URL, onTo
 
 	creds := awsCfg.Credentials
 	assumeRoleARN := q.Get("assume_role_arn")
-	sessionName := q.Get("assume_role_session_name")
+	var sessionName string
 	if assumeRoleARN != "" {
 		stsClient := sts.NewFromConfig(awsCfg)
+		sessionName = q.Get("assume_role_session_name")
 		if sessionName == "" {
 			sessionName = "pgutils-rds-iam"
 		}

--- a/pgutils/connector.go
+++ b/pgutils/connector.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"net"
 	"net/url"
 	"strings"
@@ -24,6 +23,20 @@ import (
 const defaultPostgresPort = "5432"
 
 var pqDriver = &pq.Driver{}
+
+// TokenSignEvent contains details about an RDS IAM token signing operation.
+type TokenSignEvent struct {
+	Endpoint              string
+	User                  string
+	Database              string
+	AssumeRoleARN         string // empty if no role assumption was configured
+	AssumeRoleSessionName string // empty if no role assumption was configured
+}
+
+// OnTokenSign is called each time an RDS IAM auth token is generated.
+// Clients can use this for logging, metrics, or any other observability needs.
+// Pass nil to disable notifications.
+type OnTokenSign func(event TokenSignEvent)
 
 // ConnectionStringProvider returns a Postgres connection string for use by clients
 // that need a DSN (e.g., pq.Listener) or to build a connector.
@@ -51,8 +64,9 @@ func (f connectionStringProviderFunc) ConnectionString(ctx context.Context) (str
 //
 //	postgres+rds-iam://<user>@<rds-endpoint>:<port>/<db-name>?assume_role_arn=<...>&assume_role_session_name=<...>
 //
-// For postgres+rds-iam, the provider generates a fresh IAM auth token on each ConnectionString(ctx) call.
-func NewConnectionStringProviderFromURLString(ctx context.Context, rawURL string) (ConnectionStringProvider, error) {
+// For postgres+rds-iam, the provider generates a fresh IAM auth token on each
+// ConnectionString(ctx) call and fires onTokenSign (if non-nil) after each signing.
+func NewConnectionStringProviderFromURLString(ctx context.Context, rawURL string, onTokenSign OnTokenSign) (ConnectionStringProvider, error) {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return nil, fmt.Errorf("parsing URL: %w", err)
@@ -62,7 +76,7 @@ func NewConnectionStringProviderFromURLString(ctx context.Context, rawURL string
 	case "postgres", "postgresql":
 		return &staticConnectionStringProvider{connectionString: u.String()}, nil
 	case "postgres+rds-iam":
-		return newIAMConnectionStringProviderFromURL(ctx, u)
+		return newIAMConnectionStringProviderFromURL(ctx, u, onTokenSign)
 	default:
 		return nil, fmt.Errorf("unsupported URL scheme: %q (expected postgres, postgresql, or postgres+rds-iam)", u.Scheme)
 	}
@@ -163,11 +177,14 @@ func (p *staticConnectionStringProvider) ConnectionString(ctx context.Context) (
 }
 
 type rdsIAMConnectionStringProvider struct {
-	RDSEndpoint         string
-	Region              string
-	User                string
-	Database            string
-	CredentialsProvider aws.CredentialsProvider
+	RDSEndpoint           string
+	Region                string
+	User                  string
+	Database              string
+	CredentialsProvider   aws.CredentialsProvider
+	AssumeRoleARN         string
+	AssumeRoleSessionName string
+	OnTokenSign           OnTokenSign
 }
 
 func (p *rdsIAMConnectionStringProvider) ConnectionString(ctx context.Context) (string, error) {
@@ -175,7 +192,16 @@ func (p *rdsIAMConnectionStringProvider) ConnectionString(ctx context.Context) (
 	if err != nil {
 		return "", fmt.Errorf("building auth token: %w", err)
 	}
-	log.Printf("Signing RDS IAM token for Endpoint: %s User: %s Database: %s", p.RDSEndpoint, p.User, p.Database)
+
+	if p.OnTokenSign != nil {
+		p.OnTokenSign(TokenSignEvent{
+			Endpoint:              p.RDSEndpoint,
+			User:                  p.User,
+			Database:              p.Database,
+			AssumeRoleARN:         p.AssumeRoleARN,
+			AssumeRoleSessionName: p.AssumeRoleSessionName,
+		})
+	}
 
 	dsnURL := &url.URL{
 		Scheme: "postgresql",
@@ -187,7 +213,7 @@ func (p *rdsIAMConnectionStringProvider) ConnectionString(ctx context.Context) (
 	return dsnURL.String(), nil
 }
 
-func newIAMConnectionStringProviderFromURL(ctx context.Context, u *url.URL) (ConnectionStringProvider, error) {
+func newIAMConnectionStringProviderFromURL(ctx context.Context, u *url.URL, onTokenSign OnTokenSign) (ConnectionStringProvider, error) {
 	user := ""
 	if u.User != nil {
 		user = u.User.Username()
@@ -237,13 +263,12 @@ func newIAMConnectionStringProviderFromURL(ctx context.Context, u *url.URL) (Con
 
 	creds := awsCfg.Credentials
 	assumeRoleARN := q.Get("assume_role_arn")
+	sessionName := q.Get("assume_role_session_name")
 	if assumeRoleARN != "" {
 		stsClient := sts.NewFromConfig(awsCfg)
-		sessionName := q.Get("assume_role_session_name")
 		if sessionName == "" {
 			sessionName = "pgutils-rds-iam"
 		}
-		log.Printf("RDS IAM Assuming Role: %s with session name: %s for Host: %s User: %s Database: %s", assumeRoleARN, sessionName, host, user, dbName)
 		assumeProvider := stscreds.NewAssumeRoleProvider(stsClient, assumeRoleARN, func(opts *stscreds.AssumeRoleOptions) {
 			opts.RoleSessionName = sessionName
 		})
@@ -256,5 +281,8 @@ func newIAMConnectionStringProviderFromURL(ctx context.Context, u *url.URL) (Con
 		User:                user,
 		Database:            dbName,
 		CredentialsProvider: creds,
+		AssumeRoleARN:       assumeRoleARN,
+		//AssumeRoleSessionName: sessionName,
+		OnTokenSign: onTokenSign,
 	}, nil
 }

--- a/pgutils/connector.go
+++ b/pgutils/connector.go
@@ -276,13 +276,13 @@ func newIAMConnectionStringProviderFromURL(ctx context.Context, u *url.URL, onTo
 	}
 
 	return &rdsIAMConnectionStringProvider{
-		Region:              awsCfg.Region,
-		RDSEndpoint:         net.JoinHostPort(host, port),
-		User:                user,
-		Database:            dbName,
-		CredentialsProvider: creds,
-		AssumeRoleARN:       assumeRoleARN,
-		//AssumeRoleSessionName: sessionName,
-		OnTokenSign: onTokenSign,
+		Region:                awsCfg.Region,
+		RDSEndpoint:           net.JoinHostPort(host, port),
+		User:                  user,
+		Database:              dbName,
+		CredentialsProvider:   creds,
+		AssumeRoleARN:         assumeRoleARN,
+		AssumeRoleSessionName: sessionName,
+		OnTokenSign:           onTokenSign,
 	}, nil
 }

--- a/pgutils/pgutils.go
+++ b/pgutils/pgutils.go
@@ -1,13 +1,19 @@
 package pgutils
 
 import (
+	"context"
 	"crypto/sha1"
 	"fmt"
+	"log"
 	"net/url"
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/jmoiron/sqlx"
 	"github.com/lib/pq"
 )
@@ -139,4 +145,83 @@ func CensorDSNForLogs(dsn string) string {
 		u.User = url.UserPassword(u.User.Username(), "xxx")
 	}
 	return u.String()
+}
+
+// ChainOnTokenSign combines multiple OnTokenSign callbacks into one.
+// Each callback is invoked in order for every event.
+func ChainOnTokenSign(callbacks ...OnTokenSign) OnTokenSign {
+	return func(event TokenSignEvent) {
+		for _, cb := range callbacks {
+			cb(event)
+		}
+	}
+}
+
+// LogOnTokenSign returns an OnTokenSign callback that logs each signing
+// event to the provided logger, including assume-role details when present.
+func LogOnTokenSign(logger *log.Logger) OnTokenSign {
+	return func(event TokenSignEvent) {
+		if event.AssumeRoleARN != "" {
+			logger.Printf("pgutils: signing RDS IAM token for Endpoint: %s User: %s Database: %s AssumeRoleARN: %s SessionName: %s",
+				event.Endpoint, event.User, event.Database, event.AssumeRoleARN, event.AssumeRoleSessionName)
+		} else {
+			logger.Printf("pgutils: signing RDS IAM token for Endpoint: %s User: %s Database: %s",
+				event.Endpoint, event.User, event.Database)
+		}
+	}
+}
+
+// PushCloudWatchOnTokenSign returns an OnTokenSign callback that pushes
+// RDSIAMTokenSigned metrics to CloudWatch. If the PutMetricData call fails,
+// the error is passed to onError. If onError is nil, failures are silently ignored.
+//
+// Two data points are published per event:
+//
+//  1. Dimensioned — with Endpoint, User, Database (and AssumeRoleARN when
+//     present) for per-combination drill-down.
+//  2. Aggregate — with no dimensions, for simple alarming across all
+//     combinations without Metric Math.
+func PushCloudWatchOnTokenSign(client *cloudwatch.Client, namespace string, onError func(error)) OnTokenSign {
+	return func(event TokenSignEvent) {
+		now := time.Now()
+		metricName := aws.String("RDSIAMTokenSigned")
+
+		dimensions := []types.Dimension{
+			{Name: aws.String("Endpoint"), Value: aws.String(event.Endpoint)},
+			{Name: aws.String("User"), Value: aws.String(event.User)},
+			{Name: aws.String("Database"), Value: aws.String(event.Database)},
+		}
+
+		if event.AssumeRoleARN != "" {
+			dimensions = append(dimensions, types.Dimension{
+				Name:  aws.String("AssumeRoleARN"),
+				Value: aws.String(event.AssumeRoleARN),
+			})
+		}
+
+		input := &cloudwatch.PutMetricDataInput{
+			Namespace: aws.String(namespace),
+			MetricData: []types.MetricDatum{
+				{
+					MetricName: metricName,
+					Dimensions: dimensions,
+					Timestamp:  aws.Time(now),
+					Value:      aws.Float64(1),
+					Unit:       types.StandardUnitCount,
+				},
+				{
+					MetricName: metricName,
+					Timestamp:  aws.Time(now),
+					Value:      aws.Float64(1),
+					Unit:       types.StandardUnitCount,
+				},
+			},
+		}
+
+		if _, err := client.PutMetricData(context.Background(), input); err != nil {
+			if onError != nil {
+				onError(err)
+			}
+		}
+	}
 }

--- a/pgutils/pgutils.go
+++ b/pgutils/pgutils.go
@@ -150,9 +150,9 @@ func CensorDSNForLogs(dsn string) string {
 // ChainOnTokenSign combines multiple OnTokenSign callbacks into one.
 // Each callback is invoked in order for every event.
 func ChainOnTokenSign(callbacks ...OnTokenSign) OnTokenSign {
-	return func(event TokenSignEvent) {
+	return func(ctx context.Context, event TokenSignEvent) {
 		for _, cb := range callbacks {
-			cb(event)
+			cb(ctx, event)
 		}
 	}
 }
@@ -160,7 +160,7 @@ func ChainOnTokenSign(callbacks ...OnTokenSign) OnTokenSign {
 // LogOnTokenSign returns an OnTokenSign callback that logs each signing
 // event to the provided logger, including assume-role details when present.
 func LogOnTokenSign(logger *log.Logger) OnTokenSign {
-	return func(event TokenSignEvent) {
+	return func(_ context.Context, event TokenSignEvent) {
 		if event.AssumeRoleARN != "" {
 			logger.Printf("pgutils: signing RDS IAM token for Endpoint: %s User: %s Database: %s AssumeRoleARN: %s SessionName: %s",
 				event.Endpoint, event.User, event.Database, event.AssumeRoleARN, event.AssumeRoleSessionName)
@@ -182,7 +182,7 @@ func LogOnTokenSign(logger *log.Logger) OnTokenSign {
 //  2. Aggregate — with no dimensions, for simple alarming across all
 //     combinations without Metric Math.
 func PushCloudWatchOnTokenSign(client *cloudwatch.Client, namespace string, onError func(error)) OnTokenSign {
-	return func(event TokenSignEvent) {
+	return func(ctx context.Context, event TokenSignEvent) {
 		now := time.Now()
 		metricName := aws.String("RDSIAMTokenSigned")
 
@@ -218,7 +218,7 @@ func PushCloudWatchOnTokenSign(client *cloudwatch.Client, namespace string, onEr
 			},
 		}
 
-		if _, err := client.PutMetricData(context.Background(), input); err != nil {
+		if _, err := client.PutMetricData(ctx, input); err != nil {
 			if onError != nil {
 				onError(err)
 			}

--- a/pgutils/pgutils.go
+++ b/pgutils/pgutils.go
@@ -147,16 +147,6 @@ func CensorDSNForLogs(dsn string) string {
 	return u.String()
 }
 
-// ChainOnTokenSign combines multiple OnTokenSign callbacks into one.
-// Each callback is invoked in order for every event.
-func ChainOnTokenSign(callbacks ...OnTokenSign) OnTokenSign {
-	return func(ctx context.Context, event TokenSignEvent) {
-		for _, cb := range callbacks {
-			cb(ctx, event)
-		}
-	}
-}
-
 // LogOnTokenSign returns an OnTokenSign callback that logs each signing
 // event to the provided logger, including assume-role details when present.
 func LogOnTokenSign(logger *log.Logger) OnTokenSign {


### PR DESCRIPTION
## PR Description
[CMCSMACD-5836](https://jiraent.cms.gov/browse/CMCSMACD-5836)
Create a callback function for RDS IAM on token signing. This removes log prints from the RDS IAM library, the callback path is intended for the clients to use to setup logging on their side.

Helper methods have been included for the clients to optionally use, they can also define their own.

Example client usage:

```
....
    onTokenSign := pgutils.ChainOnTokenSign(
		pgutils.LogOnTokenSign(log.Default()),
		pgutils.PushCloudWatchOnTokenSign(cloudwatch.NewFromConfig(awsCfg), "ACreminsTest/RDS", func(err error) {
			log.Printf("cloudwatch push failed: %v", err)
		}),
	)

	connectionStringProvider, err := pgutils.NewConnectionStringProviderFromURLString(ctx, rawURL, onTokenSign)
	if err != nil {
		fmt.Fprintf(os.Stderr, "failed to create connection string provider: %v\n", err)
		os.Exit(1)
	}
...
```

Tests:
Created a simple test app and verified that callback/logger helper/cloudwatch helper all worked as expected

## PR Checklist
* [x] **New automated tests have been written to the extent possible.**
* [x] **The code has been checked for structural/syntactic validity.**
	- AMI/application: a build was performed
	- terraform changes: "terraform plan" checked on every affected environment
* [x] **(If applicable) the code has been manually tested on our infrastructure.**
	- AMI/application: deployed an a test or dev environment
	- terraform changes: applied to test or dev environment
	- script: run against test or dev environment
* [x] **Likely failure points and new functionality have been identified and tested manually.**
	Examples:
	- Application manually run in a way that triggers any new branches
	- AMI logged into and changes verified from login shell
* [x] **Pull request description includes a description of all the manual steps performed to accomplish the above.**

To provide feedback on this template, visit https://docs.google.com/document/d/1YfTv7Amyop5G_8w1c2GJ_Mu-70L0KkZHhm9f9umDi3U/edit
