### PR TITLE
[CMCSMACD-6133] Support search_path in postgres+rds-iam scheme

### DIFF
--- a/pgutils/connector.go
+++ b/pgutils/connector.go
@@ -143,7 +143,10 @@ func addSearchPathToURL(rawURL string, searchPath string) (string, error) {
 	if v := q.Get("search_path"); v != "" {
 		return "", fmt.Errorf("search_path already set to %q", v)
 	}
-	q.Set("search_path", searchPath)
+	if v := q.Get("options"); v != "" {
+		return "", fmt.Errorf("options already set to %q", v)
+	}
+	q.Set("options", fmt.Sprintf("-csearch_path=%s", searchPath))
 	u.RawQuery = q.Encode()
 	return u.String(), nil
 }
@@ -247,6 +250,7 @@ func newIAMConnectionStringProviderFromURL(ctx context.Context, u *url.URL, onTo
 	supportedParams := map[string]struct{}{
 		"assume_role_arn":          {},
 		"assume_role_session_name": {},
+		"search_path":              {},
 	}
 	for k := range q {
 		if _, ok := supportedParams[k]; !ok {
@@ -278,7 +282,7 @@ func newIAMConnectionStringProviderFromURL(ctx context.Context, u *url.URL, onTo
 		creds = aws.NewCredentialsCache(assumeProvider)
 	}
 
-	return &rdsIAMConnectionStringProvider{
+	var p ConnectionStringProvider = &rdsIAMConnectionStringProvider{
 		Region:                awsCfg.Region,
 		RDSEndpoint:           net.JoinHostPort(host, port),
 		User:                  user,
@@ -287,5 +291,11 @@ func newIAMConnectionStringProviderFromURL(ctx context.Context, u *url.URL, onTo
 		AssumeRoleARN:         assumeRoleARN,
 		AssumeRoleSessionName: sessionName,
 		OnTokenSign:           onTokenSign,
-	}, nil
+	}
+
+	if searchPath := q.Get("search_path"); searchPath != "" {
+		p = WithSchemaSearchPath(p, searchPath)
+	}
+
+	return p, nil
 }

--- a/pgutils/connector.go
+++ b/pgutils/connector.go
@@ -127,23 +127,20 @@ func MustConnectDB(conn driver.Connector) *sqlx.DB {
 	return db
 }
 
-// addSearchPathToURL returns a copy of u with search_path set in the query string.
-// It returns an error if search_path is already present.
+// addSearchPathToURL returns a copy of u with search_path set in the options parameter
+// of the query string. It returns an error if the search_path or options parameter is
+// already present.
 func addSearchPathToURL(rawURL string, searchPath string) (string, error) {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return "", fmt.Errorf("url string failed to parse while adding search path: %w", err)
 	}
 
-	if searchPath == "" {
-		return u.String(), nil
-	}
-
 	q := u.Query()
-	if v := q.Get("search_path"); v != "" {
+	if v, ok := q["search_path"]; ok {
 		return "", fmt.Errorf("search_path already set to %q", v)
 	}
-	if v := q.Get("options"); v != "" {
+	if v, ok := q["options"]; ok {
 		return "", fmt.Errorf("options already set to %q", v)
 	}
 	q.Set("options", fmt.Sprintf("-csearch_path=%s", searchPath))
@@ -293,8 +290,11 @@ func newIAMConnectionStringProviderFromURL(ctx context.Context, u *url.URL, onTo
 		OnTokenSign:           onTokenSign,
 	}
 
-	if searchPath := q.Get("search_path"); searchPath != "" {
-		p = WithSchemaSearchPath(p, searchPath)
+	if searchPath, ok := q["search_path"]; ok {
+		if len(searchPath) > 1 {
+			return nil, fmt.Errorf("Multiple search_path values specified")
+		}
+		p = WithSchemaSearchPath(p, searchPath[0])
 	}
 
 	return p, nil


### PR DESCRIPTION
Also, use "config" param when adding a search path to a regular postgres DSN because that is supported by both psql and the Go pq library, whereas search_path is only supported by the latter.

Testing: successfully
- Used `cmd/rds-iam-to-dsn` with a search path to generate a DSN with a token and a search path that is valid for use with `psql`
- Used `pgutils.WithSchemaSearchPath` to add a search path and successfully connected with `pgutils.MustConnectDB` and `pgutils.ToConnector` and executed a query.

## PR Checklist
* [x] **New automated tests have been written to the extent possible.**
* [x] **The code has been checked for structural/syntactic validity.**
	- AMI/application: a build was performed
	- terraform changes: "terraform plan" checked on every affected environment
* [ ] **(If applicable) the code has been manually tested on our infrastructure.**
	- AMI/application: deployed an a test or dev environment
	- terraform changes: applied to test or dev environment
	- script: run against test or dev environment
* [x] **Likely failure points and new functionality have been identified and tested manually.**
	Examples:
	- Application manually run in a way that triggers any new branches
	- AMI logged into and changes verified from login shell
* [x] **Pull request description includes a description of all the manual steps performed to accomplish the above.**

To provide feedback on this template, visit https://docs.google.com/document/d/1YfTv7Amyop5G_8w1c2GJ_Mu-70L0KkZHhm9f9umDi3U/edit
