### PR TITLE
Enable pgaudit extension in rds-init

### DIFF
--- a/cmd/rds-init/README.md
+++ b/cmd/rds-init/README.md
@@ -1,6 +1,6 @@
 # RDS Database Initialization Tool
 
-A utility for initializing and configuring RDS PostgreSQL databases. This tool manages the `nessus_scan_user` account for security scanning and enables RDS IAM authentication for the admin user.
+A utility for initializing and configuring RDS PostgreSQL databases. This tool manages the `nessus_scan_user` account for security scanning, enables RDS IAM authentication for the admin user, and enables the `pgaudit` extension for audit logging.
 
 ## Overview
 

--- a/cmd/rds-init/README.md
+++ b/cmd/rds-init/README.md
@@ -4,11 +4,13 @@ A utility for initializing and configuring RDS PostgreSQL databases. This tool m
 
 ## Overview
 
-This tool performs two main tasks:
+This tool performs three main tasks:
 
 1. **Nessus scan user management** — Creates and maintains a dedicated database user (`nessus_scan_user`) for Nessus security scans, with credentials stored in AWS Secrets Manager.
 
 2. **RDS IAM authentication setup** — Grants the `rds_iam` role to the admin user, enabling IAM-based database authentication for future connections.
+
+3. **pgaudit extension** — Runs `CREATE EXTENSION IF NOT EXISTS pgaudit` so audit logging required by Nessus is active. The parameter group must already include `pgaudit` in `shared_preload_libraries`.
 
 ## How It Works
 

--- a/cmd/rds-init/main.go
+++ b/cmd/rds-init/main.go
@@ -254,6 +254,12 @@ func main() {
 		log.Printf("Created secret %q in Secrets Manager.", secretName)
 	}
 
+	// pgaudit requires `shared_preload_libraries = pgaudit` in the parameter
+	// group; CREATE EXTENSION is the per-database step that completes setup.
+	if _, err := db.ExecContext(ctx, "CREATE EXTENSION IF NOT EXISTS pgaudit"); err != nil {
+		log.Fatalf("Failed to create pgaudit extension: %v", err)
+	}
+
 	// 1) Ensure user exists (no password embedded)
 	ensureUserSQL := fmt.Sprintf(`
 DO $do$


### PR DESCRIPTION
https://jiraent.cms.gov/browse/CMCSMACD-6201

`rds-init` now runs `CREATE EXTENSION IF NOT EXISTS pgaudit` as part of its setup. The parameter group already loads `pgaudit` via `shared_preload_libraries`; this completes the per-database half so new RDS instances get pgaudit enabled at bootstrap rather than as a manual follow-up. Required by Nessus.

Idempotent via `IF NOT EXISTS`. No effect on existing already-initialized DBs (pgaudit already enabled manually, and `rds-init` can't be rerun against them anyway since the `rds_iam` grant disables password auth).

Tests:
Verified against a fresh test RDS instance — `\dx` shows `pgaudit` after `rds-init` completes.
