### PR TITLE
Reset the database after performing a schema test

### DIFF
--- a/cmd/schema-test/main.go
+++ b/cmd/schema-test/main.go
@@ -24,8 +24,12 @@ func main() {
 
 	err := migrations.SchemaTest(&cfg, allMigrations)
 	if err != nil {
-		log.Fatalf("Schema test failed: %s", err)
+		log.Fatalf("Frist schema test failed: %s", err)
+	}
+	err = migrations.SchemaTest(&cfg, allMigrations)
+	if err != nil {
+		log.Fatalf("Second schema test failed: %s", err)
 	}
 
-	log.Printf("Schema test succeeded!")
+	log.Printf("Schema tests succeeded!")
 }

--- a/cmd/schema-test/main.go
+++ b/cmd/schema-test/main.go
@@ -24,7 +24,7 @@ func main() {
 
 	err := migrations.SchemaTest(&cfg, allMigrations)
 	if err != nil {
-		log.Fatalf("Frist schema test failed: %s", err)
+		log.Fatalf("First schema test failed: %s", err)
 	}
 	err = migrations.SchemaTest(&cfg, allMigrations)
 	if err != nil {

--- a/migrations/verify.go
+++ b/migrations/verify.go
@@ -107,15 +107,6 @@ func migrateAndRollback(emptyDBConfig *PostgresConfig, db *sqlx.DB, allMigration
 	return err
 }
 
-func resetDB(db *sqlx.DB, migrationsToRollBack []NamedMigration) error {
-	err := Rollback(db, migrationsToRollBack, 0)
-	if err != nil {
-		return err
-	}
-	_, err = db.Exec("DROP TABLE migration")
-	return err
-}
-
 // Schema test expects a new *empty* postgres database.
 // It will:
 //  1. Apply all migrations
@@ -168,9 +159,14 @@ func SchemaTest(emptyDBConfig *PostgresConfig, allMigrations []NamedMigration) e
 			return err
 		}
 	}
-	err = resetDB(db, allMigrations)
+	// Reset database back to its initial state.
+	err = Rollback(db, allMigrations, 0)
 	if err != nil {
-		return fmt.Errorf("Error resetting DB back to starting point: %w", err)
+		return err
+	}
+	_, err = db.Exec("DROP TABLE migration")
+	if err != nil {
+		return fmt.Errorf("Error dropping migration table: %w", err)
 	}
 	return nil
 }

--- a/migrations/verify.go
+++ b/migrations/verify.go
@@ -107,6 +107,15 @@ func migrateAndRollback(emptyDBConfig *PostgresConfig, db *sqlx.DB, allMigration
 	return err
 }
 
+func resetDB(db *sqlx.DB, migrationsToRollBack []NamedMigration) error {
+	err := Rollback(db, migrationsToRollBack, 0)
+	if err != nil {
+		return err
+	}
+	_, err = db.Exec("DROP TABLE migration")
+	return err
+}
+
 // Schema test expects a new *empty* postgres database.
 // It will:
 //  1. Apply all migrations
@@ -158,6 +167,10 @@ func SchemaTest(emptyDBConfig *PostgresConfig, allMigrations []NamedMigration) e
 		if err != nil {
 			return err
 		}
+	}
+	err = resetDB(db, allMigrations)
+	if err != nil {
+		return fmt.Errorf("Error resetting DB back to starting point: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Verify that this works by running the schema test twice.
